### PR TITLE
perf: mark data as clean after sort

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,6 +179,8 @@ module.exports = class SparseArray {
     if (this._changedData) {
       this._data.sort(sortInternal)
     }
+
+    this._changedData = false
   }
 
   bitField () {


### PR DESCRIPTION
I'm seeing this module do quite a lot of sorting which becomes quite a hot CPU path.

It looks like it sorts the data on access of `.length` or when `.get` is invoked.  It checks the `this._changedData` field to decide whether it should sort, which is set to `true` by the `.set` method but never set to `false` afterwards.

This PR changes it to `false` after sorting.  In a run of the tests from this module it goes from sorting the various arrays 6471 times to 307.